### PR TITLE
change cakephp min version to 3.4 and above

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require":{
-        "cakephp/cakephp": "3.*",
+        "cakephp/cakephp": ">=3.4.0",
         "league/factory-muffin": "^3.0",
         "league/factory-muffin-faker": "^2.0", 
         "cakephp/plugin-installer": "*"


### PR DESCRIPTION
When using with a lower version of CakePHP lower than 3.4, it throws error due to some deprecated functions like getSource. This is due to change in CakePHP api to be compatible with PSR standarts.